### PR TITLE
Added 'MaxLcmRuntime' feature to 'DscLcmController'

### DIFF
--- a/CommonTasks/DscResources/Scripts/Scripts.schema.psm1
+++ b/CommonTasks/DscResources/Scripts/Scripts.schema.psm1
@@ -8,7 +8,7 @@ configuration Scripts {
 
     foreach ($item in $Items) {
 
-        $executionName = "Script_$($s.Name)"
+        $executionName = "Script_$($item.Name)"
         [void]$item.Remove('Name')
         (Get-DscSplattedResource -ResourceName xScript -ExecutionName $executionName -Properties $item -NoInvoke).Invoke($item)
 

--- a/CommonTasks/Tests/Integration/Assets/Config/DscLcmController.yml
+++ b/CommonTasks/Tests/Integration/Assets/Config/DscLcmController.yml
@@ -6,3 +6,4 @@ RefreshInterval: 04:00:00
 RefreshIntervalOverride: false
 ControllerInterval: 00:15:00
 MaintenanceWindowOverride: false
+MaxLcmRuntime: 02:00:00


### PR DESCRIPTION
Sometimes the LCM hangs and is not killed by the DscTimer. You can view the active DSC providers like this:

```powershell
Get-CimInstance -Query 'SELECT * FROM MSFT_Providers WHERE provider LIKE "dsc%"' | Select-Object -ExpandProperty provider
```

The DscLcmController triggers the LCM in the background now and waits until 'MaxLcmRuntime' has passed. It then kills the 'dsccore' process.

The DscLcmController unloads the 'dsctimer' provider so the LCM won't be triggered by the system anymore. The only exception is when the machine starts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/commontasks/56)
<!-- Reviewable:end -->
