### PR TITLE
Casting into string ignores the machines locale and returns the data …

### DIFF
--- a/CommonTasks/DscResources/DscTagging/DscTagging.schema.psm1
+++ b/CommonTasks/DscResources/DscTagging/DscTagging.schema.psm1
@@ -51,7 +51,7 @@ configuration DscTagging {
     xRegistry DscBuildDate {
         Key       = 'HKEY_LOCAL_MACHINE\SOFTWARE\DscTagging'
         ValueName = 'BuildDate'
-        ValueData = Get-Date
+        ValueData = [string](Get-Date)
         ValueType = 'String'
         Ensure    = 'Present'
         Force     = $true


### PR DESCRIPTION
…in en-us format

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/commontasks/100)
<!-- Reviewable:end -->
