### PR TITLE
[Cluster] Fix when NodeMajority is used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Removed dependencies for faster build.
 - Fixed badges.
 - Added back configurations and dependencies.
+- Fixing issue with Cluster when only NodeMajority is used

--- a/source/DSCResources/Cluster/Cluster.schema.psm1
+++ b/source/DSCResources/Cluster/Cluster.schema.psm1
@@ -59,7 +59,7 @@ configuration Cluster
             Name                          = $Name
             DomainAdministratorCredential = $DomainAdministratorCredential
             DependsOn                     = '[xWaitForCluster]WaitForCluster'
-        } 
+        }
     }
     else {
         xCluster NewCluster {
@@ -77,10 +77,18 @@ configuration Cluster
     }
 
     if (-not $Join) {
-        xClusterQuorum ClusterQuorum {
-            IsSingleInstance = 'Yes'
-            Type             = $QuorumType
-            Resource         = $QuorumResource
+        if ($QuorumType -eq 'NodeMajority') {
+            xClusterQuorum ClusterQuorum {
+                IsSingleInstance = 'Yes'
+                Type             = $QuorumType
+            }
+        }
+        else {
+            xClusterQuorum ClusterQuorum {
+                IsSingleInstance = 'Yes'
+                Type             = $QuorumType
+                Resource         = $QuorumResource
+            }
         }
     }
 


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description
### Fixed
- Issue with Cluster composite, when only NodeMajority is used for parameter QuorumType

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).


Comment: Local build does not work at all, so I am not sure how to test my change properly

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/commontasks/129)
<!-- Reviewable:end -->
