### PR TITLE
fixing the LCM config to RebootNodeIfNeeded $false in Monitor mode…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,3 +23,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixing issue with AddsOrgUnitsAndGroups when OUs contain other non-word characters.
 - Added MmaAgent to configure Microsoft Monitoring Agent.
 - Added AddsServicePrincipalNames to configure SPNs.
+- Disabling RebootNodeIfNeeded when LCM is on Monitor mode.

--- a/source/DSCResources/DscLcmController/DscLcmController.schema.psm1
+++ b/source/DSCResources/DscLcmController/DscLcmController.schema.psm1
@@ -212,6 +212,17 @@ function Set-LcmMode {
 
     $pattern = '(ConfigurationMode(\s+)?=(\s+)?)("\w+")(;)'
     $content = $content -replace $pattern, ('$1 "{0}"$5' -f $Mode)
+    # If mode is ApplyAndMonitor, set to not reboot, if set to ApplyAndAutoCorrect, set to reboot if needed
+    [bool] $rebootIfNeeded = $True
+    if ($Mode -eq 'ApplyAndMonitor') {
+        $rebootIfNeeded = $False
+    }
+    else {
+        $rebootIfNeeded = $True
+    }
+
+    $patternRebootNodeIfNeeded = '(RebootNodeIfNeeded(\s+)?=(\s+)?)(true|false);'
+    $content = $content -replace $patternRebootNodeIfNeeded, ('$1 {0};' -f $RebootIfNeeded)
 
     $content | Out-File -FilePath $mofFile.FullName -Encoding unicode
 


### PR DESCRIPTION
As described and discussed @raandree .

When the LCM is not in maintenance window, but you run a consistency check and there's a DSC Pending reboot, the consistency check will restart your machine.

To fix that, now when the LCM is set to Monitor mode, Reboot if needed will be disabled, and when set to Autocorrect, the Reboot if needed will be enabled.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/commontasks/136)
<!-- Reviewable:end -->
