### PR TITLE
[DscLcmController]The RebootNodeIfNeeded property is not set to false before the first maintenance window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,3 +42,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue with names containing special characters in 'LocalUsers' and 'LocalGroups' resources.
 - Fixed issue with quotation marks in 'SqlServer' resource.
 - Fixed issue with inter-configuration DependsOn by removing DependsOn inside configurations
+- Fixed an issue with DscLcmController, the RebootNodeIfNeeded property is not
+set to false before the first execution of maintenance window.


### PR DESCRIPTION
…

# Pull Request
## Pull Request (PR) description

### Changed
- Fixed an issue with DscLcmController, the RebootNodeIfNeeded property is not
set to false before the first execution of maintenance window.

Before the first execution of scheduled task in maintenance window, the RebootNodeIfNeeded property of LCM isn't force to false. This cause unwanted reboots in the system.



## Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/commontasks/153)
<!-- Reviewable:end -->
