### PR TITLE
Fix #172 -  RegistryPolicies: Error when Key or ValueName parameters contain bracket "()"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,3 +65,4 @@ set to true when the LCM is already in ApplyAndAutoCorrect mode.
 - Migration of tests to Pester 5
 - Added support for CimInstance parameters
 - Fixed issue with Cluster composite ignoring the IgnoreNetwork parameter
+- Fix #172 - RegistryPolicies: Error when Key or ValueName parameters contain bracket "()"

--- a/doc/CertificateExports.adoc
+++ b/doc/CertificateExports.adoc
@@ -13,7 +13,6 @@
 [[dscyml_certificateexports_abstract, {abstract}]]
 {abstract}
 
-
 [cols="1,3a" options="autowidth" caption=]
 |===
 | Source         | \https://github.com/dsccommunity/CommonTasks/tree/main/source/DSCResources/CertificateImports
@@ -40,8 +39,8 @@
 |===
 
 
-[[dscyml_certificateexports_certfiles_details]]
-.Selected Attributes of category '<<dscyml_certificateexports_certfiles>>'
+[[dscyml_certificateexports_certificates_details]]
+.Selected Attributes of category '<<dscyml_certificateexports_certificates>>'
 [cols="1,1,1,2a,1a" options="header"]
 |===
 | Parameter

--- a/source/DSCResources/RegistryPolicies/RegistryPolicies.schema.psm1
+++ b/source/DSCResources/RegistryPolicies/RegistryPolicies.schema.psm1
@@ -53,7 +53,7 @@ configuration RegistryPolicies {
             }
             $value.Remove('Force')
         }
-        $executionName = "$($value.Key)\$($value.ValueName)" -replace "[\s\\:*-+/{}```"']", '_'
+        $executionName = "$($value.Key)\$($value.ValueName)" -replace "[\s()\\:*-+/{}```"']", '_'
         (Get-DscSplattedResource -ResourceName RegistryPolicyFile -ExecutionName $executionName -Properties $value -NoInvoke).Invoke($value)
 
         $refreshCounter += 1


### PR DESCRIPTION
# Pull Request
## Pull Request (PR) description

Fix #172 -  RegistryPolicies: Error when Key or ValueName parameters contain bracket "()"

### Fixed
- fix #172


## Task list

- [X] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [X] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [ ] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [X] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/commontasks/173)
<!-- Reviewable:end -->
