### PR TITLE
Made reading binary files in FilesAndFolders and CertificateImports m…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,3 +69,4 @@ set to true when the LCM is already in ApplyAndAutoCorrect mode.
 - Fix #172 - RegistryPolicies: Error when Key or ValueName parameters contain bracket "()"
 - ConfigurationManagerDeployment updated to allow Windows feature installation
   - InstallWindowsFeatures could create duplicate resource issues if WindowsFeatures composite is used as well
+- Made reading binary files in FilesAndFolders and CertificateImports more robust

--- a/source/DSCResources/CertificateImports/CertificateImports.schema.psm1
+++ b/source/DSCResources/CertificateImports/CertificateImports.schema.psm1
@@ -13,6 +13,7 @@ configuration CertificateImports
 
     Import-DscResource -Module PSDesiredStateConfiguration
     Import-DscResource -Module CertificateDsc
+
     function EmbedFile
     {
         [System.Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSAvoidUsingWriteHost', '')]
@@ -33,7 +34,8 @@ configuration CertificateImports
                 }
                 else
                 {
-                    $certFile.Content = [Convert]::ToBase64String([IO.File]::ReadAllBytes($certFile.Path))
+                    $certFilePath = Resolve-Path $certFile.Path
+                    $certFile.Content = [Convert]::ToBase64String([System.IO.File]::ReadAllBytes($certFilePath))
                     $certFile.Remove('Path')
                 }
             }

--- a/source/DSCResources/FilesAndFolders/FilesAndFolders.schema.psm1
+++ b/source/DSCResources/FilesAndFolders/FilesAndFolders.schema.psm1
@@ -45,8 +45,9 @@ configuration FilesAndFolders
                 }
                 elseif ( $item.Type -eq 'BinaryFile' )
                 {
-                    $fileHash      = (Get-FileHash -Path $item.ContentFromFile -Algorithm SHA256).Hash
-                    $base64Content = [Convert]::ToBase64String([IO.File]::ReadAllBytes($item.ContentFromFile))
+                    $filePath      = Resolve-Path $item.ContentFromFile
+                    $fileHash      = (Get-FileHash -Path $filePath -Algorithm SHA256).Hash
+                    $base64Content = [Convert]::ToBase64String([IO.File]::ReadAllBytes($filePath))
                 }
                 else
                 {


### PR DESCRIPTION
# Pull Request

Made reading binary files in FilesAndFolders and CertificateImports more robust.

## Task list

- [X] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [X] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [X] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/commontasks/177)
<!-- Reviewable:end -->
