### PR TITLE
Fixed type errors in 'RemoteDesktopCollections' and 'RemoteDesktopDeployment'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,3 +79,4 @@ set to true when the LCM is already in ApplyAndAutoCorrect mode.
 - ConfigurationManagerDeployment now has configurable Product Key.
 - Made reading binary files in FilesAndFolders and CertificateImports more robust.
 - Updated to latest version of 'PackageManagement' to fix module discovery error.
+- Made 'SessionHost' a scalar as defined in the underlying DSC resource for 'RemoteDesktopCollections' and 'RemoteDesktopDeployment'.

--- a/source/DSCResources/RemoteDesktopDeployment/RemoteDesktopDeployment.schema.psm1
+++ b/source/DSCResources/RemoteDesktopDeployment/RemoteDesktopDeployment.schema.psm1
@@ -11,8 +11,8 @@ configuration RemoteDesktopDeployment
         $WebAccess,
 
         [Parameter()]
-        [string[]]
-        $SessionHosts,
+        [string]
+        $SessionHost,
 
         [Parameter()]
         [hashtable[]]
@@ -26,7 +26,7 @@ configuration RemoteDesktopDeployment
     {
         ConnectionBroker = $ConnectionBroker
         WebAccessServer  = $WebAccess
-        SessionHost      = $SessionHosts
+        SessionHost      = $SessionHost
     }
 
     foreach ($gateway in $Gateways)

--- a/tests/Unit/DSCResources/Assets/Config/RemoteDesktopCollections.yml
+++ b/tests/Unit/DSCResources/Assets/Config/RemoteDesktopCollections.yml
@@ -1,14 +1,10 @@
 ﻿Collections:
   - CollectionName: My first Collection
-    SessionHost:
-      - SH1
-      - SH2
+    SessionHost: SH1
     CollectionDescription: This is my super awesome collection
     ConnectionBroker: CB1
   - CollectionName: My second Collection
-    SessionHost:
-      - SH1
-      - SH2
+    SessionHost: SH1
     CollectionDescription: This is my super awesome collection number 2
     ConnectionBroker: CB1
     Settings:

--- a/tests/Unit/DSCResources/Assets/Config/RemoteDesktopDeployment.yml
+++ b/tests/Unit/DSCResources/Assets/Config/RemoteDesktopDeployment.yml
@@ -1,5 +1,3 @@
 ﻿ConnectionBroker: CB1
-SessionHosts:
-  - SH1
-  - SH2
+SessionHost: SH1
 WebAccess: WA1

--- a/tests/Unit/DSCResources/DscResources.Tests.ps1
+++ b/tests/Unit/DSCResources/DscResources.Tests.ps1
@@ -2,7 +2,7 @@ BeforeDiscovery {
     $dscResources = Get-DscResource -Module $moduleUnderTest.Name
     $here = $PSScriptRoot
 
-    $skippedDscResources = 'PowerShellRepositories', 'RemoteDesktopCollections', 'RemoteDesktopDeployment'
+    $skippedDscResources = ''
 
     Import-Module -Name datum
 


### PR DESCRIPTION
# Pull Request

Pester tests failed for 'RemoteDesktopCollections' and 'RemoteDesktopDeploymentMade'.  'SessionHost' defined as an array but is a [scalar in the underlying DSC resources](https://github.com/dsccommunity/xRemoteDesktopSessionHost/blob/42739cd37327b8e2437831cae151dc2d6f23dbcf/source/DSCResources/MSFT_xRDSessionCollection/MSFT_xRDSessionCollection.psm1#L57).

## Pull Request (PR) description

### Fixed
- SessionHost is now a scalar in 'RemoteDesktopCollections' and 'RemoteDesktopDeploymentMade'.

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
