### PR TITLE
Fixed Typo in AddsDomainController Documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,3 +105,4 @@ set to true when the LCM is already in ApplyAndAutoCorrect mode.
   due to an encoding issue with the psd1 file
 - Add missing documentation
 - Added Read-Only Domaincontroller Variable to AddsDomainController
+- Fixed Typo in AddsDomainController documentation

--- a/doc/AddsDomainController.adoc
+++ b/doc/AddsDomainController.adoc
@@ -71,7 +71,7 @@
 | The name of the site this Domain Controller will be added to.
 |
 
-| IsGlobalCatalog
+| IsReadOnlyReplica
 |
 | Boolean
 | Specifies if the domain controller will be a Read-Only Domain Controller (RODC).
@@ -109,7 +109,7 @@ AddsDomainController:
   IsGlobalCatalog: true
   InstallationMediaPath: \\Server\Share
 
-  AddsDomainController:
+AddsDomainController:
   DomainName: contoso.com
   Credential: '[ENC=PE9ian...=]'
   SafeModeAdministratorPassword: '[ENC=PE9ian...=]'


### PR DESCRIPTION
# Pull Request

I accidently made a silly copy & paste error in the Documentation

## Pull Request (PR) description

### Fixed
- Fixed Typo in AddsDomainController Documentation



## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [x] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/CommonTasks/204)
<!-- Reviewable:end -->
