### PR TITLE
New resource DhcpServerAuthorization & add Networks support to FailoverCluster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+
+### Added
+
+- AddsDomainController:
+    - add UnprotectFromAccidentalDeletion to allow dc promote if an existing AD computer account is protected
+- DhcpServerAuthorization:
+    - new resource to authorize DHCP server in AD
+- FailoverCluster:
+    - add Networks support
+    - add installation of required Windows Features
+    - update documentation
+
+### Changed
+
+- DHCPServer:
+    - fix EnableSecurityGroups if resource is not running on a domain controller
+- HyperV:
+    - remove unused code after migration to HyperVDsc
+
+
 ## [0.9.0] - 2023-02-08
 
 ### Added

--- a/doc/AddsDomainController.adoc
+++ b/doc/AddsDomainController.adoc
@@ -66,12 +66,14 @@
 | Default: `C:\Windows\SYSVOL`
 
 | SiteName
-|
+| Mandatory
 | String
 | The name of the site this Domain Controller will be added to.
+
+Set value to 'Default-First-Site-Name' if the Domain Controller shall be added to default site.
 |
 
-| IsGlobalCatalog
+| IsReadOnlyReplica
 |
 | Boolean
 | Specifies if the domain controller will be a Read-Only Domain Controller (RODC).
@@ -84,6 +86,15 @@
 | Specifies if the domain controller will be a Global Catalog (GC).
 | - *True* (default)
   - False
+
+| UnprotectFromAccidentalDeletion
+|
+| Boolean
+| Specifies if the 'Protect from accidental deletion' flag shall be removed from the AD computer account *before* promoting to a domain controller.
+
+If the computer acts as domain controller the 'Protect from accidental deletion' flag will not changed anymore.
+| - *False* (default)
+  - True
 
 | InstallationMediaPath
 |
@@ -107,16 +118,7 @@ AddsDomainController:
   SysvolPath: C:\Windows\SYSVOL
   SiteName: London
   IsGlobalCatalog: true
-  InstallationMediaPath: \\Server\Share
-
-  AddsDomainController:
-  DomainName: contoso.com
-  Credential: '[ENC=PE9ian...=]'
-  SafeModeAdministratorPassword: '[ENC=PE9ian...=]'
-  LogPath: C:\Windows\Logs
-  SysvolPath: C:\Windows\SYSVOL
-  SiteName: Berlin
   IsReadOnlyReplica: true
-  IsGlobalCatalog: true
-
+  UnprotectFromAccidentalDeletion: true
+  InstallationMediaPath: \\Server\Share
 ----

--- a/doc/DhcpServerAuthorization.adoc
+++ b/doc/DhcpServerAuthorization.adoc
@@ -1,0 +1,65 @@
+// CommonTasks YAML Reference: DhcpServerAuthorization
+// ===================================================
+
+:YmlCategory: DhcpServerAuthorization
+
+:abstract: {YmlCategory} manages the authorizations of a DHCP server in Active Directory.
+
+[#dscyml_dhcpserverauthorization]
+= DSC Resource '{YmlCategory}'
+
+[[dscyml_dhcpserverauthorization_abstract, {abstract}]]
+{abstract}
+
+
+[cols="1,3a" options="autowidth" caption=]
+|===
+| Source         | https://github.com/dsccommunity/CommonTasks/tree/main/source/DSCResources/DhcpServerAuthorization
+| DSC Resource   | https://github.com/dsccommunity/xDhcpServer[xDhcpServer]
+| Documentation  | https://github.com/dsccommunity/xDhcpServer/wiki/xDhcpServerAuthorization[xDhcpServerAuthorization]
+|===
+
+
+IMPORTANT: This resource must run on an Active Directory domain controller.
+
+
+.Attributes of category '{YmlCategory}'
+[cols="1,1,1,2a,1a" options="header"]
+|===
+| Parameter
+| Attribute
+| DataType
+| Description
+| Allowed Values
+
+| DnsName
+|
+| String
+| DHCP Server FQDN or empty string for `localhost`.
+|
+
+| IPAddress
+|
+| String
+| DHCP Server IP Address or empty string for `localhost`.
+|
+
+| Ensure
+|
+| String
+| Whether the DHCP server should be authorized within Active Directory
+| - *Present* (default)
+  - Removed
+
+|===
+
+
+.Example
+[source, yaml]
+----
+DhcpServerAuthorization:
+    # authorize remote DHCP server
+    DnsName: dhcp.contoso.com
+    IPAddress: 192.168.1.12
+    Ensure: Present
+----

--- a/doc/FailoverCluster.adoc
+++ b/doc/FailoverCluster.adoc
@@ -1,5 +1,5 @@
-// CommonTasks YAML Reference: Cluster
-// ===================================
+// CommonTasks YAML Reference: FailoverCluster
+// ===========================================
 
 :YmlCategory: FailoverCluster
 
@@ -9,19 +9,20 @@
 = DSC Resource '{YmlCategory}'
 
 
-[[dscyml_failover_abstract, {abstract}]]
+[[dscyml_failovercluster_abstract, {abstract}]]
 {abstract}
 
 
 [cols="1,3a" options="autowidth" caption=]
 |===
-| Source         | https://github.com/dsccommunity/CommonTasks/tree/main/source/DSCResources/Cluster
+| Source         | https://github.com/dsccommunity/CommonTasks/tree/main/source/DSCResources/FailoverCluster
 | DSC Resource   | - https://github.com/dsccommunity/FailoverClusterDsc[FailoverClusterDsc]
                    - https://github.com/dsccommunity/ActiveDirectoryDsc[ActiveDirectoryDsc]
-| Documentation  | - https://github.com/dsccommunity/FailoverClusterDsc/wiki/WaitForCluster[WaitForCluster]
-                   - https://github.com/dsccommunity/FailoverClusterDsc/wiki/Cluster[Cluster]
+| Documentation  | - https://github.com/dsccommunity/FailoverClusterDsc/wiki/Cluster[Cluster]
                    - https://github.com/dsccommunity/FailoverClusterDsc/wiki/ClusterDisk[ClusterDisk]
+                   - https://github.com/dsccommunity/FailoverClusterDsc/wiki/ClusterNetwork[ClusterNetwork]
                    - https://github.com/dsccommunity/FailoverClusterDsc/wiki/ClusterQuorum[ClusterQuorum]
+                   - https://github.com/dsccommunity/FailoverClusterDsc/wiki/WaitForCluster[WaitForCluster]
                    - https://github.com/dsccommunity/ActiveDirectoryDsc/wiki/ADObjectPermissionEntry[ADObjectPermissionEntry]
 |===
 
@@ -85,10 +86,16 @@ If this is not specified then the cluster computer object must have been prestag
 This parameter is optional if the quorum type is set to `NodeMajority`.
 |
 
-| [[dscyml_failover_disks, {YmlCategory}/Disks]]<<dscyml_failover_disks_details, Disks>>
+| [[dscyml_failovercluster_disks, {YmlCategory}/Disks]]<<dscyml_failovercluster_disks_details, Disks>>
 |
 | Hashtable[]
 | Configures shared disks in a cluster.
+|
+
+| [[dscyml_failovercluster_networks, {YmlCategory}/Networks]]<<dscyml_failovercluster_networks_details, Networks>>
+|
+| Hashtable[]
+| Configures cluster networks in a failover cluster.
 |
 
 | Join
@@ -129,8 +136,8 @@ When creating a cluster role the cluster service is creating the needed computer
 |===
 
 
-[[dscyml_failover_disks_details]]
-.Attributes of DSC Resource '<<dscyml_failover_disks>>'
+[[dscyml_failovercluster_disks_details]]
+.Attributes of DSC Resource '<<dscyml_failovercluster_disks>>'
 [cols="1,1,1,2a,1a" options="header"]
 |===
 | Parameter
@@ -161,6 +168,63 @@ When creating a cluster role the cluster service is creating the needed computer
 |===
 
 
+[[dscyml_failovercluster_networks_details]]
+.Attributes of DSC Resource '<<dscyml_failovercluster_networks>>'
+[cols="1,1,1,2a,1a" options="header"]
+|===
+| Parameter
+| Attribute
+| DataType
+| Description
+| Allowed Values
+
+| Address
+| Key
+| String
+| The address for the cluster network in the format `10.0.0.0`.
+|
+
+| AddressMask
+| Key
+| String
+| The address mask for the cluster network in the format `255.255.255.0`.
+|
+
+| Name
+|
+| String
+| The name of the cluster network.
+
+If the cluster network name is not in desired state it will be renamed to match this name.
+|
+
+| Role
+|
+| String
+| The role of the cluster network.
+
+If the cluster network role is not in desired state it will change to match this role.
+
+The cluster network role can be set to either the value 0, 1 or 3.
+
+- 0 -> Do not allow cluster network communication
+- 1 -> Allow cluster network communication only
+- 3 -> Allow cluster network communication and client connectivity
+| - 0
+  - 1
+  - 3
+
+| Metric
+|
+| String
+| The metric number for the cluster network.
+
+If the cluster network metric number is not in desired state it will be changed to match this metric number.	
+|
+
+|===
+
+
 .Example
 [source, yaml]
 ----
@@ -186,4 +250,34 @@ FailoverCluster:
       Label: Disk4
     - Number: 5
       Label: Disk5
+  Networks:
+    - Address:     192.168.0.0
+      AddressMask: 255.255.255.0
+      Name:        ClusterCom
+      Role:        3
+    - Address:     192.168.1.0
+      AddressMask: 255.255.255.0
+      Name:        NoClusterCom
+      Role:        0
+----
+
+
+.Recommended Lookup Options in `Datum.yml` (Excerpt)
+[source, yaml]
+----
+lookup_options:
+
+  FailoverCluster:
+    merge_hash: deep
+  FailoverCluster\Disks:
+    merge_hash_array: UniqueKeyValTuples
+    merge_options:
+      tuple_keys:
+        - Number
+  FailoverCluster\Networks:
+    merge_hash_array: UniqueKeyValTuples
+    merge_options:
+      tuple_keys:
+        - Address
+        - AddressMask
 ----

--- a/doc/HyperV.adoc
+++ b/doc/HyperV.adoc
@@ -451,21 +451,10 @@ The first entry will be the OS disk (C:\).
 | MAC-Address of the network adapter
 |
 
-| IgnoreNetworkSetting
-|
-| Boolean
-| Specifies whether the IpAddress information for the network adapter is set or ignored
-| - *True* (default)
-  - False
-
 | [[dscyml_hyperv_vmmachines_networkadapters_networksetting, {YmlCategory}/VMMachines/NetworkAdapters/NetworkSetting]]<<dscyml_hyperv_vmmachines_networkadapters_networksetting_details, NetworkSetting>>
 |
 | Hashtable
 | Network settings
-
-If `IgnoreNetworkSetting` is set to `True` the network settings are ignored.
-
-*If network settings are not specified and parameter `IgnoreNetworkSetting` is set to `False` DHCP will be enabled on the network adapter.*
 |
 
 | VlanId

--- a/doc/README.adoc
+++ b/doc/README.adoc
@@ -92,6 +92,7 @@ ifdef::env-github[]
 - <<DhcpScopeOptions.adoc#, DhcpScopeOptions>>
 - <<DhcpScopes.adoc#, DhcpScopes>>
 - <<DhcpServer.adoc#, DhcpServer>>
+- <<DhcpServerAuthorization.adoc#, DhcpServerAuthorization>>
 - <<DhcpServerOptionDefinitions.adoc#, DhcpServerOptionDefinitions>>
 - <<DhcpServerOptions.adoc#, DhcpServerOptions>>
 - <<DiskAccessPaths.adoc#, DiskAccessPaths>>
@@ -245,7 +246,6 @@ ifndef::env-github[]
 | <<dscyml_chocolateypackages>>                     | <<dscyml_chocolateypackages_abstract>>
 | <<dscyml_chocolateypackages2nd>>                  | <<dscyml_chocolateypackages2nd_abstract>>
 | <<dscyml_chocolateypackages3rd>>                  | <<dscyml_chocolateypackages3rd_abstract>>
-| <<dscyml_cluster>>                                | <<dscyml_cluster_abstract>>
 | <<dscyml_computersettings>>                       | <<dscyml_computersettings_abstract>>
 | <<dscyml_configurationbase>>                      | <<dscyml_configurationbase_abstract>>
 | <<dscyml_configurationmanagerconfiguration>>      | <<dscyml_configurationmanagerconfiguration_abstract>>
@@ -255,6 +255,7 @@ ifndef::env-github[]
 | <<dscyml_dhcpscopeoptions>>                       | <<dscyml_dhcpscopeoptions_abstract>>
 | <<dscyml_dhcpscopes>>                             | <<dscyml_dhcpscopes_abstract>>
 | <<dscyml_dhcpserver>>                             | <<dscyml_dhcpserver_abstract>>
+| <<dscyml_dhcpserverauthorization>>                | <<dscyml_dhcpserverauthorization_abstract>>
 | <<dscyml_dhcpserveroptiondefinitions>>            | <<dscyml_dhcpserveroptiondefinitions_abstract>>
 | <<dscyml_dhcpserveroptions>>                      | <<dscyml_dhcpserveroptions_abstract>>
 | <<dscyml_diskaccesspaths>>                        | <<dscyml_diskaccesspaths_abstract>>
@@ -285,6 +286,7 @@ ifndef::env-github[]
 | <<dscyml_exchangemailboxdatabasecopies>>          | <<dscyml_exchangemailboxdatabasecopies_abstract>>
 | <<dscyml_exchangemailboxdatabases>>               | <<dscyml_exchangemailboxdatabases_abstract>>
 | <<dscyml_exchangeprovisioning>>                   | <<dscyml_exchangeprovisioning_abstract>>
+| <<dscyml_failovercluster>>                        | <<dscyml_failovercluster_abstract>>
 | <<dscyml_filecontents>>                           | <<dscyml_filecontents_abstract>>
 | <<dscyml_filesandfolders>>                        | <<dscyml_filesandfolders_abstract>>
 | <<dscyml_firewallprofiles>>                       | <<dscyml_firewallprofiles_abstract>>
@@ -421,8 +423,6 @@ include::ChocolateyPackages2nd.adoc[leveloffset=+1]
 <<<<
 include::ChocolateyPackages3rd.adoc[leveloffset=+1]
 <<<<
-include::Cluster.adoc[leveloffset=+1]
-<<<<
 include::ComputerSettings.adoc[leveloffset=+1]
 <<<<
 include::ConfigurationBase.adoc[leveloffset=+1]
@@ -440,6 +440,8 @@ include::DhcpScopeOptions.adoc[leveloffset=+1]
 include::DhcpScopes.adoc[leveloffset=+1]
 <<<<
 include::DhcpServer.adoc[leveloffset=+1]
+<<<<
+include::DhcpServerAuthorization.adoc[leveloffset=+1]
 <<<<
 include::DhcpServerOptionDefinitions.adoc[leveloffset=+1]
 <<<<
@@ -500,6 +502,8 @@ include::ExchangeMailboxDatabaseCopies.adoc[leveloffset=+1]
 include::ExchangeMailboxDatabases.adoc[leveloffset=+1]
 <<<<
 include::ExchangeProvisioning.adoc[leveloffset=+1]
+<<<<
+include::FailoverCluster.adoc[leveloffset=+1]
 <<<<
 include::FileContents.adoc[leveloffset=+1]
 <<<<

--- a/source/DSCResources/DhcpServerAuthorization/DhcpServerAuthorization.psd1
+++ b/source/DSCResources/DhcpServerAuthorization/DhcpServerAuthorization.psd1
@@ -1,0 +1,15 @@
+@{
+    RootModule           = 'DhcpServerAuthorization.schema.psm1'
+
+    ModuleVersion        = '0.0.1'
+
+    GUID                 = '0eca96ba-9eeb-483e-8ddd-c1786e527615'
+
+    Author               = 'NA'
+
+    CompanyName          = 'NA'
+
+    Copyright            = 'NA'
+
+    DscResourcesToExport = @('DhcpServerAuthorization')
+}

--- a/source/DSCResources/DhcpServerAuthorization/DhcpServerAuthorization.schema.psm1
+++ b/source/DSCResources/DhcpServerAuthorization/DhcpServerAuthorization.schema.psm1
@@ -1,0 +1,34 @@
+# see https://github.com/dsccommunity/xDhcpServer
+configuration DhcpServerAuthorization
+{
+    param
+    (
+        [Parameter()]
+        [ValidateSet( 'Present', 'Absent' )]
+        [string] $Ensure = 'Present',
+
+        [Parameter()]
+        [string] $DnsName,
+
+        [Parameter()]
+        [string] $IpAddress
+    )
+
+    Import-DscResource -ModuleName PSDesiredStateConfiguration
+    Import-DscResource -ModuleName xDhcpServer
+
+    WindowsFeature DHCPServerTools
+    {
+        Name   = 'RSAT-DHCP'
+        Ensure = 'Present'
+    }
+
+    xDhcpServerAuthorization DHCPServerAuthorization
+    {
+        IsSingleInstance = 'Yes'
+        DnsName          = $DnsName
+        IpAddress        = $IpAddress
+        Ensure           = $Ensure
+        DependsOn        = '[WindowsFeature]DHCPServerTools'
+    }
+}

--- a/tests/Unit/DSCResources/Assets/Config/AddsDomainController.yml
+++ b/tests/Unit/DSCResources/Assets/Config/AddsDomainController.yml
@@ -5,6 +5,7 @@ DatabasePath: C:\Windows\NTDS
 LogPath: C:\Windows\Logs
 SysvolPath: C:\Windows\SYSVOL
 SiteName: London
-IsReadOnlyReplica: true
 IsGlobalCatalog: true
+IsReadOnlyReplica: false
+UnprotectFromAccidentalDeletion: true
 InstallationMediaPath: \\Server\Share

--- a/tests/Unit/DSCResources/Assets/Config/DhcpServerAuthorization.yml
+++ b/tests/Unit/DSCResources/Assets/Config/DhcpServerAuthorization.yml
@@ -1,0 +1,3 @@
+# DnsName: dhcp.contoso.com
+# IPAddress: 192.168.1.12
+Ensure: Present

--- a/tests/Unit/DSCResources/Assets/Config/FailoverCluster.yml
+++ b/tests/Unit/DSCResources/Assets/Config/FailoverCluster.yml
@@ -19,3 +19,12 @@ Disks:
     Label: Disk4
   - Number: 5
     Label: Disk5
+Networks:
+  - Address:     192.168.0.0
+    AddressMask: 255.255.255.0
+    Name:        ClusterCom
+    Role:        3
+  - Address:     192.168.1.0
+    AddressMask: 255.255.255.0
+    Name:        NoClusterCom
+    Role:        0


### PR DESCRIPTION
# Pull Request

### Added

- AddsDomainController:
    - add UnprotectFromAccidentalDeletion to allow dc promote if an existing AD computer account is protected
- DhcpServerAuthorization:
    - new resource to authorize DHCP server in AD
- FailoverCluster:
    - add Networks support
    - add installation of required Windows Features
    - update documentation

### Changed

- DHCPServer:
    - fix EnableSecurityGroups if resource is not running on a domain controller
- HyperV:
    - remove unused code after migration to HyperVDsc

## Task list

- [X] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [X] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [X] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [X] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [X] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
