### PR TITLE
Moved the configurations `WindowsFeatures` and `WindowsOptionalFeature` to `xPSDesiredStateConfiguration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - remove unused code after migration to HyperVDsc
 - Pipeline
   - Updated to latest Sampler files and update an vmImage reference to `ubuntu-latest`
+- `WindowsOptionalFeatures` is using the DSC resource in `xPSDesiredStateConfiguration` now.
 
 ## [0.9.0] - 2023-02-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - remove unused code after migration to HyperVDsc
 - Pipeline
   - Updated to latest Sampler files and update an vmImage reference to `ubuntu-latest`
-- `WindowsOptionalFeatures` is using the DSC resource in `xPSDesiredStateConfiguration` now.
+- `WindowsOptionalFeatures` and `WindowsFeatures` are using the DSC resource in `xPSDesiredStateConfiguration` now.
 
 ## [0.9.0] - 2023-02-08
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,6 +16,7 @@ variables:
   buildArtifactName: output
   testResultFolderName: testResults
   defaultBranch: main
+  Agent.Source.Git.ShallowFetchDepth: 0
 
 stages:
   - stage: Build

--- a/doc/WindowsFeatures.adoc
+++ b/doc/WindowsFeatures.adoc
@@ -11,12 +11,15 @@
 [[dscyml_windowsfeatures_abstract, {abstract}]]
 {abstract}
 
+// reference links as variables for using more than once
+:ref_xpsdesiredstateconfiguration_xwindowsfeature:    https://github.com/dsccommunity/xPSDesiredStateConfiguration#xwindowsfeature[xwindowsfeature]
+
 
 [cols="1,3a" options="autowidth" caption=]
 |===
-| Source         | https://github.com/dsccommunity/CommonTasks/tree/main/source/DSCResources/WindowsFeatures
-| DSC Resource   | https://docs.microsoft.com/en-us/powershell/module/psdesiredstateconfiguration[PSDesiredStateConfiguration]
-| Documentation  | https://docs.microsoft.com/de-de/powershell/scripting/dsc/reference/resources/windows/windowsfeatureresource[WindowsFeature]
+| Source         | https://github.com/dsccommunity/CommonTasks/tree/main/source/DSCResources/WindowsOptionalFeatures
+| DSC Resource   | https://github.com/dsccommunity/xPSDesiredStateConfiguration[xPSDesiredStateConfiguration]
+| Documentation  | {ref_xpsdesiredstateconfiguration_xwindowsfeature}
 |===
 
 
@@ -45,7 +48,7 @@ This is the same as the Name property from the `Get-WindowsFeature` cmdlet, and 
 | [+ \| -]<name>
 
 | [[dscyml_windowsfeatures_features, {YmlCategory}/Features]]<<dscyml_windowsfeatures_features_details, Features>>
-| 
+|
 | Hashtable[]
 | List windows features with additional properties
 |
@@ -108,6 +111,14 @@ To ensure that the role or feature is removed, set the property to `Absent`.
 | - *Present* (default)
   - Absent
 
+| UseLegacyResource
+|
+| String
+| Indicates if the resource `WindowsFeature` should be used instead of the `xWindowsFeature` resource.
+
+| - *false* (default)
+  - true
+
 |===
 
 
@@ -123,6 +134,7 @@ WindowsFeatures:
   Features:
     - Name: NET-Framework-Core
       Source: \\contoso.com\InstallationSources\WinSxs
+      UseLegacyResource: true
     - Name: RSAT-AD-Tools
       IncludeAllSubFeature: true
 ----

--- a/doc/WindowsOptionalFeatures.adoc
+++ b/doc/WindowsOptionalFeatures.adoc
@@ -8,15 +8,18 @@
 [#dscyml_windowsoptionalfeatures]
 = DSC Resource '{YmlCategory}'
 
-[[dscyml_windowsoptionalfeatures_abstract, {abstract}]]
+[[dscyml_windowsoptionalfeature_abstract, {abstract}]]
 {abstract}
+
+// reference links as variables for using more than once
+:ref_xpsdesiredstateconfiguration_xwindowsoptionalfeature:    https://github.com/dsccommunity/xPSDesiredStateConfiguration#xWindowsOptionalFeature[xWindowsOptionalFeature]
 
 
 [cols="1,3a" options="autowidth" caption=]
 |===
 | Source         | https://github.com/dsccommunity/CommonTasks/tree/main/source/DSCResources/WindowsOptionalFeatures
-| DSC Resource   | https://docs.microsoft.com/en-us/powershell/module/psdesiredstateconfiguration[PSDesiredStateConfiguration]
-| Documentation  | https://docs.microsoft.com/de-de/powershell/scripting/dsc/reference/resources/windows/windowsoptionalfeatureresource[WindowsOptionalFeature]
+| DSC Resource   | https://github.com/dsccommunity/xPSDesiredStateConfiguration[xPSDesiredStateConfiguration]
+| Documentation  | {ref_xpsdesiredstateconfiguration_xwindowsoptionalfeature}
 |===
 
 
@@ -33,7 +36,7 @@
 | Mandatory
 | string
 | Indicates the name of the feature that you want to ensure is added or removed.
-  This is the same as the Name property from the Get-WindowsOptionalFeature cmdlet, and not the display name of the feature.
+  This is the same as the Name property from the `Get-WindowsOptionalFeature` cmdlet, and not the display name of the feature.
 | [+ \| -]<name>
 
 | RemoveFilesOnDisable

--- a/source/DSCResources/WindowsFeatures/WindowsFeatures.schema.psm1
+++ b/source/DSCResources/WindowsFeatures/WindowsFeatures.schema.psm1
@@ -6,10 +6,23 @@ configuration WindowsFeatures {
 
         [Parameter()]
         [hashtable[]]
-        $Features
+        $Features,
+
+        [Parameter()]
+        [bool]$UseLegacyResource = $false
     )
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration
+    Import-DscResource -ModuleName xPSDesiredStateConfiguration
+
+    $resourceName = if ($UseLegacyResource)
+    {
+        'WindowsFeature'
+    }
+    else
+    {
+        'xWindowsFeature'
+    }
 
     foreach ($n in $Names)
     {
@@ -35,7 +48,7 @@ configuration WindowsFeatures {
             IncludeAllSubFeature = $includeAllSubFeature
         }
 
-        (Get-DscSplattedResource -ResourceName WindowsFeature -ExecutionName $params.Name -Properties $params -NoInvoke).Invoke($params)
+        (Get-DscSplattedResource -ResourceName $resourceName -ExecutionName $params.Name -Properties $params -NoInvoke).Invoke($params)
     }
 
     <#
@@ -52,6 +65,16 @@ configuration WindowsFeatures {
     #>
     foreach ($feature in $Features)
     {
-        (Get-DscSplattedResource -ResourceName WindowsFeature -ExecutionName $feature.Name -Properties $feature -NoInvoke).Invoke($feature)
+        $resourceName = if ($feature.UseLegacyResource)
+        {
+            'WindowsFeature'
+        }
+        else
+        {
+            'xWindowsFeature'
+        }
+        $feature.remove('UseLegacyResource')
+
+        (Get-DscSplattedResource -ResourceName $resourceName -ExecutionName $feature.Name -Properties $feature -NoInvoke).Invoke($feature)
     }
 }

--- a/source/DSCResources/WindowsOptionalFeatures/WindowsOptionalFeatures.schema.psm1
+++ b/source/DSCResources/WindowsOptionalFeatures/WindowsOptionalFeatures.schema.psm1
@@ -14,6 +14,7 @@ configuration WindowsOptionalFeatures {
     )
 
     Import-DscResource -ModuleName PSDesiredStateConfiguration
+    Import-DscResource -ModuleName xPSDesiredStateConfiguration
 
     foreach ($n in $Names)
     {
@@ -35,6 +36,6 @@ configuration WindowsOptionalFeatures {
             NoWindowsUpdateCheck = $NoWindowsUpdateCheck
         }
 
-        (Get-DscSplattedResource -ResourceName WindowsOptionalFeature -ExecutionName $params.Name -Properties $params -NoInvoke).Invoke($params)
+        (Get-DscSplattedResource -ResourceName xWindowsOptionalFeature -ExecutionName $params.Name -Properties $params -NoInvoke).Invoke($params)
     }
 }

--- a/source/DSCResources/WindowsOptionalFeatures/WindowsOptionalFeatures.schema.psm1
+++ b/source/DSCResources/WindowsOptionalFeatures/WindowsOptionalFeatures.schema.psm1
@@ -18,13 +18,13 @@ configuration WindowsOptionalFeatures {
 
     foreach ($n in $Names)
     {
-        $ensure = 'Enable'
+        $ensure = 'Present'
 
         if ($n[0] -in '-', '+')
         {
             if ($n[0] -eq '-')
             {
-                $ensure = 'Disable'
+                $ensure = 'Absent'
             }
             $n = $n.Substring(1)
         }

--- a/tests/Unit/DSCResources/Assets/Config/WindowsFeatures.yml
+++ b/tests/Unit/DSCResources/Assets/Config/WindowsFeatures.yml
@@ -6,5 +6,8 @@ Names:
 Features:
   - Name: NET-Framework-Core
     Source: \\contoso.com\InstallationSources\WinSxs
+    UseLegacyResource: true
+  - Name: NET-Framework-Core
+    UseLegacyResource: false
   - Name: RSAT-AD-Tools
     IncludeAllSubFeature: true


### PR DESCRIPTION
# Pull Request

## Pull Request (PR) description

For `WindowsFeatures` to use the old `WindowsFeature` DSC Resource use of `PSDesiredStateConfiguration`, use `UseLegacyResource`. 

### Changed
- Moved the configurations `WindowsFeatures` and `WindowsOptionalFeature` to `xPSDesiredStateConfiguration`.

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [x] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).
