### PR TITLE
CertificateRequests supports multiple certificates with the same issu…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pipeline
   - Updated to latest Sampler files and update an vmImage reference to `ubuntu-latest`
 - `WindowsOptionalFeatures` and `WindowsFeatures` are using the DSC resource in `xPSDesiredStateConfiguration` now.
+- `CertificateRequests` supports multiple certificates with the same issuer and subject by making friendlyName a mandatory (key) parameter.
 
 ## [0.9.0] - 2023-02-08
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -58,7 +58,7 @@
     PowerShellGet                = '2.2.5'
     ConfigMgrCBDsc               = '3.0.0'
     MmaDsc                       = '1.3.0'
-    CertificateDsc               = '5.1.0'
+    CertificateDsc               = '6.0.0-preview0001'
     xRobocopy                    = '2.0.0.0'
     VSTSAgent                    = '2.0.14'
     FileContentDsc               = '1.3.0.151'

--- a/doc/CertificateRequests.adoc
+++ b/doc/CertificateRequests.adoc
@@ -55,13 +55,13 @@
 |
 
 | CAType
-| 
+|
 | String
 | The type of CA in use, Standalone/Enterprise.
 |
 
 | CAServerFQDN
-| 
+|
 | String
 | The FQDN of the Active Directory Certificate Authority on the local area network.
 
@@ -69,7 +69,7 @@ Leave empty to automatically locate.
 |
 
 | CARootName
-| 
+|
 | String
 | The name of the certificate authority, by default this will be in format domain-servername-ca.
 
@@ -77,7 +77,7 @@ Leave empty to automatically locate.
 |
 
 | KeyLength
-| 
+|
 | String
 | The bit length of the encryption key to be used.
 | - 192
@@ -91,69 +91,69 @@ Leave empty to automatically locate.
   - 8192
 
 | Exportable
-| 
+|
 | Boolean
 | The option to allow the certificate to be exportable.
 | - *True* (default)
   - False
 
 | ProviderName
-| 
+|
 | String
 | The selection of provider for the type of encryption to be used.
 |
 
 | OID
-| 
+|
 | String
 | The Object Identifier that is used to name the object.
 |
 
 | KeyUsage
-| 
+|
 | String
 | The Keyusage is a restriction method that determines what a certificate can be used for.
 |
 
 | CertificateTemplate
-| 
+|
 | String
 | The template used for the definition of the certificate.
 |
 
 | SubjectAltName
-| 
+|
 | String
 | The subject alternative name used to create the certificate.
 |
 
 | Credential
-| 
+|
 | PSCredential
 | The `PSCredential` object containing the credentials that will be used to access the template in the Certificate Authority.
 |
 
 | AutoRenew
-| 
+|
 | Boolean
 | Determines if the resource will also renew a certificate within 7 days of expiration.
 | - True
   - False
 
 | CepURL
-| 
+|
 | String
 | The URL to the Certification Enrollment Policy Service.
 |
 
 | CesURL
-| 
+|
 | String
 | The URL to the Certification Enrollment Service.
 |
 
 | UseMachineContext
-| 
+|
 | Boolean
 | Indicates whether or not the flag `-adminforcemachine` will be used when requesting certificates.
   Necessary for certain templates like e.g. DomainControllerAuthentication
@@ -161,20 +161,20 @@ Leave empty to automatically locate.
   - False
 
 | FriendlyName
-| 
+| Key
 | String
 | Specifies a friendly name for the certificate.
 |
 
 | KeyType
-| 
+|
 | String
 | Specifies if the key type should be `RSA` or `ECDH`.
 | - *RSA* (default)
   - ECDH
 
-| RequestType	
-| 
+| RequestType
+|
 | String
 | Specifies if the request type should be `CMC` or `PKCS10`.
 | - *CMC* (default)

--- a/source/DSCResources/CertificateRequests/CertificateRequests.schema.psm1
+++ b/source/DSCResources/CertificateRequests/CertificateRequests.schema.psm1
@@ -8,27 +8,30 @@ configuration CertificateRequests
     )
 
     <#
-        Subject = [string]
-        [AutoRenew = [bool]]
-        [CARootName = [string]]
-        [CAServerFqdn = [string]]
-        [CAType = [string]]
-        [CepURL = [string]]
-        [CertificateTemplate = [string]]
-        [CesURL = [string]]
-        [Credential = [PSCredential]]
-        [DependsOn = [string[]]]
-        [Exportable = [bool]]
-        [FriendlyName = [string]]
-        [KeyLength = [string]{ 1024 | 192 | 2048 | 224 | 256 | 384 | 4096 | 521 | 8192 }]
-        [KeyType = [string]{ ECDH | RSA }]
-        [KeyUsage = [string]]
-        [OID = [string]]
-        [ProviderName = [string]]
-        [PsDscRunAsCredential = [PSCredential]]
-        [RequestType = [string]{ CMC | PKCS10 }]
-        [SubjectAltName = [string]]
-        [UseMachineContext = [bool]]
+        CertReq [String] #ResourceName
+        {
+            FriendlyName = [string]
+            Subject = [string]
+            [AutoRenew = [bool]]
+            [CARootName = [string]]
+            [CAServerFQDN = [string]]
+            [CAType = [string]]
+            [CepURL = [string]]
+            [CertificateTemplate = [string]]
+            [CesURL = [string]]
+            [Credential = [PSCredential]]
+            [DependsOn = [string[]]]
+            [Exportable = [bool]]
+            [KeyLength = [string]{ 1024 | 192 | 2048 | 224 | 256 | 384 | 4096 | 521 | 8192 }]
+            [KeyType = [string]{ ECDH | RSA }]
+            [KeyUsage = [string]]
+            [OID = [string]]
+            [ProviderName = [string]]
+            [PsDscRunAsCredential = [PSCredential]]
+            [RequestType = [string]{ CMC | PKCS10 }]
+            [SubjectAltName = [string]]
+            [UseMachineContext = [bool]]
+        }
     #>
 
     Import-DscResource -Module PSDesiredStateConfiguration
@@ -51,7 +54,7 @@ configuration CertificateRequests
         }
 
         $request.DependsOn = "[WaitForCertificateServices]WaitForADCS$($request.CARootName -replace '[\s(){}/\\:=-]', '_')"
-        $executionName = "req_$($request.Subject)" -replace '[\s(){}/\\:=\.-]', '_'
+        $executionName = "req_$($request.FriendlyName)_$($request.Subject)" -replace '[\s(){}/\\:=\.-]', '_'
         (Get-DscSplattedResource -ResourceName CertReq -ExecutionName $executionName -Properties $request -NoInvoke).Invoke($request)
     }
 }


### PR DESCRIPTION
…er and subject by making friendlyName a mandatory (key) parameter

# Pull Request

## Pull Request (PR) description

### Changed
- `CertificateRequests` supports multiple certificates with the same issuer and subject by making friendlyName a mandatory (key) parameter.

## Task list

- [x] The PR represents a single logical change. i.e. Cosmetic updates should go in different PRs.
- [x] Added an entry under the Unreleased section of in the CHANGELOG.md as per [format](https://keepachangelog.com/en/1.0.0/).
- [x] Local clean build passes without issue or fail tests (`build.ps1 -ResolveDependency`).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/CommonTasks/215)
<!-- Reviewable:end -->
